### PR TITLE
fix: allow legacy `allowfullscreen`

### DIFF
--- a/built/general.js
+++ b/built/general.js
@@ -103,6 +103,9 @@ async function getOEmbedPlayer($, pageUrl) {
     const allowedPermissions = (iframe.attr('allow') ?? '').split(/\s*;\s*/g)
         .filter(s => s)
         .filter(s => !ignoredList.includes(s));
+    if (iframe.attr('allowfullscreen') === '') {
+        allowedPermissions.push('fullscreen');
+    }
     if (allowedPermissions.some(allow => !safeList.includes(allow))) {
         // This iframe is probably too powerful to be embedded
         return null;

--- a/src/general.ts
+++ b/src/general.ts
@@ -115,6 +115,9 @@ async function getOEmbedPlayer($: cheerio.CheerioAPI, pageUrl: string): Promise<
 		(iframe.attr('allow') ?? '').split(/\s*;\s*/g)
 			.filter(s => s)
 			.filter(s => !ignoredList.includes(s));
+	if (iframe.attr('allowfullscreen') === '') {
+		allowedPermissions.push('fullscreen');
+	}
 	if (allowedPermissions.some(allow => !safeList.includes(allow))) {
 		// This iframe is probably too powerful to be embedded
 		return null;

--- a/test/index.ts
+++ b/test/index.ts
@@ -294,7 +294,14 @@ describe("oEmbed", () => {
 		await setUpFastify('oembed-allow-fullscreen.json');
 		const summary = await summaly(host);
 		expect(summary.player.url).toBe('https://example.com/');
-		expect(summary.player.allow).toStrictEqual(['fullscreen'])
+		expect(summary.player.allow).toStrictEqual(['fullscreen']);
+	});
+
+	test('allows legacy allowfullscreen', async () => {
+		await setUpFastify('oembed-allow-fullscreen-legacy.json');
+		const summary = await summaly(host);
+		expect(summary.player.url).toBe('https://example.com/');
+		expect(summary.player.allow).toStrictEqual(['fullscreen']);
 	});
 
 	test('allows safelisted permissions', async () => {

--- a/test/oembed/oembed-allow-fullscreen-legacy.json
+++ b/test/oembed/oembed-allow-fullscreen-legacy.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0",
+  "type": "rich",
+  "html": "<iframe src='https://example.com/' allowfullscreen></iframe>",
+  "width": 500,
+  "height": 300
+}


### PR DESCRIPTION
YouTubeのフルスクリーンボタンが壊れていましたのでそれの修正です