### PR TITLE
enhance(parse): sensitive判定を強化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 (unreleased)
 ------------------
+* センシティブフラグの判定を `<meta property="rating">` および `rating` ヘッダでも行うように
 * 依存関係の更新
 * eslintの設定を更新
 

--- a/src/general.ts
+++ b/src/general.ts
@@ -138,6 +138,18 @@ export type GeneralScrapingOptions = {
 	contentLengthRequired?: boolean;
 }
 
+function headerEqualValueContains(search: string, headerValue: string | string[] | undefined) {
+	if (!headerValue) {
+		return false;
+	}
+
+	if (Array.isArray(headerValue)) {
+		return headerValue.some(value => value.toLowerCase() === search.toLowerCase());
+	}
+
+	return headerValue.toLowerCase() === search.toLowerCase();
+}
+
 export async function parseGeneral(_url: URL | string, opts?: GeneralScrapingOptions): Promise<Summary | null> {
 	let lang = opts?.lang;
 	if (lang && !lang.match(/^[\w-]+(\s*,\s*[\w-]+)*$/)) lang = null;
@@ -235,7 +247,11 @@ export async function parseGeneral(_url: URL | string, opts?: GeneralScrapingOpt
 
 	// https://developer.mixi.co.jp/connect/mixi_plugin/mixi_check/spec_mixi_check/#toc-18-
 	const sensitive =
-		$('meta[property=\'mixi:content-rating\']').attr('content') === '1';
+		$('meta[property=\'mixi:content-rating\']').attr('content') === '1' ||
+		headerEqualValueContains('adult', res.response.headers.rating) ||
+		headerEqualValueContains('RTA-5042-1996-1400-1577-RTA', res.response.headers.rating) ||
+		$('meta[name=\'rating\']').attr('content') === 'adult' ||
+		$('meta[name=\'rating\']').attr('content')?.toUpperCase() === 'RTA-5042-1996-1400-1577-RTA';
 
 	const find = async (path: string) => {
 		const target = new URL(path, url.href);

--- a/test/htmls/meta-adult-sensitive.html
+++ b/test/htmls/meta-adult-sensitive.html
@@ -1,0 +1,13 @@
+<!doctype html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="rating" content="adult">
+		<title>SENSITIVE CONTENT!!</title>
+	</head>
+	<body>
+		<h1>Yo</h1>
+		<p>Hey hey hey syuilo.</p>
+	</body>
+</html>

--- a/test/htmls/meta-rta-sensitive.html
+++ b/test/htmls/meta-rta-sensitive.html
@@ -1,0 +1,13 @@
+<!doctype html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="rating" content="RTA-5042-1996-1400-1577-RTA">
+		<title>SENSITIVE CONTENT!!</title>
+	</head>
+	<body>
+		<h1>Yo</h1>
+		<p>Hey hey hey syuilo.</p>
+	</body>
+</html>

--- a/test/index.ts
+++ b/test/index.ts
@@ -531,6 +531,56 @@ describe('sensitive', () => {
 		await app.listen({ port });
 		expect((await summaly(host)).sensitive).toBe(true);
 	});
+
+	test('meta rating adult', async () => {
+		app = fastify();
+		app.get('/', (request, reply) => {
+			const content = fs.readFileSync(_dirname + '/htmls/meta-adult-sensitive.html');
+			reply.header('content-length', content.length);
+			reply.header('content-type', 'text/html');
+			return reply.send(content);
+		});
+		await app.listen({ port });
+		expect((await summaly(host)).sensitive).toBe(true);
+	});
+
+	test('meta rating rta', async () => {
+		app = fastify();
+		app.get('/', (request, reply) => {
+			const content = fs.readFileSync(_dirname + '/htmls/meta-rta-sensitive.html');
+			reply.header('content-length', content.length);
+			reply.header('content-type', 'text/html');
+			return reply.send(content);
+		});
+		await app.listen({ port });
+		expect((await summaly(host)).sensitive).toBe(true);
+	});
+
+	test('HTTP Header rating adult', async () => {
+		app = fastify();
+		app.get('/', (request, reply) => {
+			const content = fs.readFileSync(_dirname + '/htmls/basic.html');
+			reply.header('content-length', content.length);
+			reply.header('content-type', 'text/html');
+			reply.header('rating', 'adult');
+			return reply.send(content);
+		});
+		await app.listen({ port });
+		expect((await summaly(host)).sensitive).toBe(true);
+	});
+
+	test('HTTP Header rating rta', async () => {
+		app = fastify();
+		app.get('/', (request, reply) => {
+			const content = fs.readFileSync(_dirname + '/htmls/basic.html');
+			reply.header('content-length', content.length);
+			reply.header('content-type', 'text/html');
+			reply.header('rating', 'RTA-5042-1996-1400-1577-RTA');
+			return reply.send(content);
+		});
+		await app.listen({ port });
+		expect((await summaly(host)).sensitive).toBe(true);
+	});
 });
 
 describe('UserAgent', () => {


### PR DESCRIPTION
Fix #21

センシティブフラグの判定を `<meta property="rating">` および `rating` ヘッダでも行うように with test