### PR TITLE
Add fediverse creator tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,16 @@ A Promise of an Object that contains properties below:
 
 | Property        | Type               | Description                                                |
 |:----------------|:-------------------|:-----------------------------------------------------------|
-| **title**       | *string* \| *null* | The title of the web page                                  |
-| **icon**        | *string* \| *null* | The url of the icon of the web page                        |
-| **description** | *string* \| *null* | The description of the web page                            |
-| **thumbnail**   | *string* \| *null* | The url of the thumbnail of the web page                   |
-| **sitename**    | *string* \| *null* | The name of the web site                                   |
-| **player**      | *Player*           | The player of the web page                                 |
-| **sensitive**   | *boolean*          | Whether the url is sensitive                               |
-| **activityPub** | *string* \| *null* | The url of the ActivityPub representation of that web page |
-| **url**         | *string*           | The url of the web page                                    |
+| **title**            | *string* \| *null* | The title of the web page                                  |
+| **icon**             | *string* \| *null* | The url of the icon of the web page                        |
+| **description**      | *string* \| *null* | The description of the web page                            |
+| **thumbnail**        | *string* \| *null* | The url of the thumbnail of the web page                   |
+| **sitename**         | *string* \| *null* | The name of the web site                                   |
+| **player**           | *Player*           | The player of the web page                                 |
+| **sensitive**        | *boolean*          | Whether the url is sensitive                               |
+| **activityPub**      | *string* \| *null* | The url of the ActivityPub representation of that web page |
+| **fediverseCreator** | *string* \| *null* | The pages fediverse handle                                 |
+| **url**              | *string*           | The url of the web page                                    |
 
 #### Summary
 

--- a/src/general.ts
+++ b/src/general.ts
@@ -245,6 +245,9 @@ export async function parseGeneral(_url: URL | string, opts?: GeneralScrapingOpt
 	const activityPub =
 		$('link[rel="alternate"][type="application/activity+json"]').attr('href') || null;
 
+	const fediverseCreator: string | null = 
+		$('meta[name=\'fediverse:creator\']').attr('content') || null;
+
 	// https://developer.mixi.co.jp/connect/mixi_plugin/mixi_check/spec_mixi_check/#toc-18-
 	const sensitive =
 		$('meta[property=\'mixi:content-rating\']').attr('content') === '1' ||
@@ -293,5 +296,6 @@ export async function parseGeneral(_url: URL | string, opts?: GeneralScrapingOpt
 		sitename: siteName || null,
 		sensitive,
 		activityPub,
+		fediverseCreator,
 	};
 }

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -38,6 +38,11 @@ type Summary = {
 	 * The url of the ActivityPub representation of that web page
 	 */
 	activityPub: string | null;
+	
+	/**
+	* The @ handle of a fediverse user (https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/)
+	*/
+ 	fediverseCreator: string | null;
 };
 
 export type SummalyResult = Summary & {

--- a/test/htmls/fediverse-creator.html
+++ b/test/htmls/fediverse-creator.html
@@ -1,0 +1,13 @@
+<!doctype html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="fediverse:creator" content="@test@example.com">
+		<title>Meow</title>
+	</head>
+	<body>
+		<h1>Hellooo!</h1>
+		<p>:3</p>
+	</body>
+</html>

--- a/test/index.ts
+++ b/test/index.ts
@@ -73,6 +73,7 @@ test('basic', async () => {
 		sensitive: false,
 		url: host + '/',
 		activityPub: null,
+		fediverseCreator: null,
 	});
 });
 
@@ -102,6 +103,7 @@ test('Stage Bye Stage', async () => {
 			'sitename': 'YouTube',
 			'sensitive': false,
 			'activityPub': null,
+			'fediverseCreator': null,
 			'url': 'https://www.youtube.com/watch?v=NMIEAhH_fTU',
 		},
 	);
@@ -504,6 +506,36 @@ describe('ActivityPub', () => {
 
 		const summary = await summaly(host);
 		expect(summary.activityPub).toBe(null);
+	});
+});
+
+describe('Fediverse Creator', () => {
+	test('Basic', async () => {
+		app = fastify();
+		app.get('*', (request, reply) => {
+			const content = fs.readFileSync(_dirname + '/htmls/fediverse-creator.html');
+			reply.header('content-length', content.length);
+			reply.header('content-type', 'text/html');
+			return reply.send(content);
+		});
+		await app.listen({ port });
+
+		const summary = await summaly(host);
+		expect(summary.fediverseCreator).toBe('@test@example.com');
+	});
+
+	test('Null', async () => {
+		app = fastify();
+		app.get('*', (request, reply) => {
+			const content = fs.readFileSync(_dirname + '/htmls/basic.html');
+			reply.header('content-length', content.length);
+			reply.header('content-type', 'text/html');
+			return reply.send(content);
+		});
+		await app.listen({ port });
+
+		const summary = await summaly(host);
+		expect(summary.fediverseCreator).toBeNull();
 	});
 });
 


### PR DESCRIPTION
This PR adds the [fediverse:creator](https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/) tag to summaly.