### PR TITLE
enhance: twitter:card を返すように

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ A Promise of an Object that contains properties below:
 | **icon**             | *string* \| *null* | The url of the icon of the web page                        |
 | **description**      | *string* \| *null* | The description of the web page                            |
 | **thumbnail**        | *string* \| *null* | The url of the thumbnail of the web page                   |
+| **thumbnailStyle**   | *"summary"* \| *"summary_large_image"* \| *null* | The display style of the thumbnail                         |
 | **sitename**         | *string* \| *null* | The name of the web site                                   |
 | **player**           | *Player*           | The player of the web page                                 |
 | **sensitive**        | *boolean*          | Whether the url is sensitive                               |
@@ -135,9 +136,10 @@ will be ... ↓
 ```json
 {
 	"title": "【アイドルマスター】「Stage Bye Stage」(歌：島村卯月、渋谷凛、本田未央)",
-	"icon": "https://www.youtube.com/s/desktop/711fd789/img/logos/favicon.ico",
+	"icon": "https://www.youtube.com/s/desktop/14cba078/img/favicon.ico",
 	"description": "Website▶https://columbia.jp/idolmaster/Playlist▶https://www.youtube.com/playlist?list=PL83A2998CF3BBC86D2018年7月18日発売予定THE IDOLM@STER CINDERELLA GIRLS CG STAR...",
 	"thumbnail": "https://i.ytimg.com/vi/NMIEAhH_fTU/maxresdefault.jpg",
+	"thumbnailStyle": null,
 	"player": {
 		"url": "https://www.youtube.com/embed/NMIEAhH_fTU?feature=oembed",
 		"width": 200,
@@ -154,6 +156,7 @@ will be ... ↓
 	"sitename": "YouTube",
 	"sensitive": false,
 	"activityPub": null,
+	"fediverseCreator": null,
 	"url": "https://www.youtube.com/watch?v=NMIEAhH_fTU"
 }
 ```

--- a/src/general.ts
+++ b/src/general.ts
@@ -206,6 +206,11 @@ export async function parseGeneral(_url: URL | string, res: Awaited<ReturnType<t
 
 	image = image ? (new URL(image, url.href)).href : null;
 
+	const thumbnailStyle =
+		twitterCard === 'summary_large_image' ? 'summary_large_image' :
+		twitterCard === 'summary' ? 'summary' :
+		null;
+
 	const playerUrl =
 		(twitterCard !== 'summary_large_image' && $('meta[name="twitter:player"]').attr('content')) ||
 		(twitterCard !== 'summary_large_image' && $('meta[property="twitter:player"]').attr('content')) ||
@@ -295,6 +300,7 @@ export async function parseGeneral(_url: URL | string, res: Awaited<ReturnType<t
 		icon: icon?.href || null,
 		description: description || null,
 		thumbnail: image || null,
+		thumbnailStyle,
 		player: oEmbed ?? {
 			url: playerUrl || null,
 			width: Number.isNaN(playerWidth) ? null : playerWidth,

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -20,6 +20,11 @@ type Summary = {
 	thumbnail: string | null;
 
 	/**
+	 * The display style of the thumbnail of that web page
+	 */
+	thumbnailStyle: 'summary' | 'summary_large_image' | null;
+
+	/**
 	 * The name of site of that web page
 	 */
 	sitename: string | null;
@@ -38,7 +43,7 @@ type Summary = {
 	 * The url of the ActivityPub representation of that web page
 	 */
 	activityPub: string | null;
-	
+
 	/**
 	* The @ handle of a fediverse user (https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/)
 	*/

--- a/test/htmls/twitter-card-player.html
+++ b/test/htmls/twitter-card-player.html
@@ -1,0 +1,12 @@
+<!doctype html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta property="twitter:card" content="player">
+		<title>Twitter player card</title>
+	</head>
+	<body>
+		<h1>Yo</h1>
+	</body>
+</html>

--- a/test/htmls/twitter-card-summary-large-image.html
+++ b/test/htmls/twitter-card-summary-large-image.html
@@ -1,0 +1,12 @@
+<!doctype html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta property="twitter:card" content="summary_large_image">
+		<title>Twitter summary large image card</title>
+	</head>
+	<body>
+		<h1>Yo</h1>
+	</body>
+</html>

--- a/test/htmls/twitter-card-summary.html
+++ b/test/htmls/twitter-card-summary.html
@@ -1,0 +1,12 @@
+<!doctype html>
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta property="twitter:card" content="summary">
+		<title>Twitter summary card</title>
+	</head>
+	<body>
+		<h1>Yo</h1>
+	</body>
+</html>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -61,9 +61,10 @@ describe('network tests', () => {
 		expect(summary).toEqual(
 			{
 				'title': '【アイドルマスター】「Stage Bye Stage」(歌：島村卯月、渋谷凛、本田未央)',
-				'icon': 'https://www.youtube.com/s/desktop/78bc1359/img/logos/favicon.ico',
+				'icon': 'https://www.youtube.com/s/desktop/14cba078/img/favicon.ico',
 				'description': 'Website▶https://columbia.jp/idolmaster/Playlist▶https://www.youtube.com/playlist?list=PL83A2998CF3BBC86D2018年7月18日発売予定THE IDOLM@STER CINDERELLA GIRLS CG STAR...',
 				'thumbnail': 'https://i.ytimg.com/vi/NMIEAhH_fTU/maxresdefault.jpg',
+				'thumbnailStyle': null,
 				'player': {
 					'url': 'https://www.youtube.com/embed/NMIEAhH_fTU?feature=oembed',
 					'width': 200,
@@ -128,6 +129,7 @@ describe('local tests', () => {
 			icon: null,
 			description: null,
 			thumbnail: null,
+			thumbnailStyle: null,
 			player: {
 				url: null,
 				width: null,
@@ -335,6 +337,25 @@ describe('local tests', () => {
 
 			const summary = await summaly(host);
 			expect(summary.thumbnail).toBe('https://himasaku.net/himasaku.png');
+		});
+
+		test.each([
+			['missing', 'basic.html', null],
+			['summary', 'twitter-card-summary.html', 'summary'],
+			['summary_large_image', 'twitter-card-summary-large-image.html', 'summary_large_image'],
+			['unsupported', 'twitter-card-player.html', null],
+		])('thumbnailStyle: %s', async (_label, html, expected) => {
+			app = fastify();
+			app.get('/', (request, reply) => {
+				const content = fs.readFileSync(_dirname + `/htmls/${html}`);
+				reply.header('content-length', content.length);
+				reply.header('content-type', 'text/html');
+				return reply.send(content);
+			});
+			await app.listen({ port });
+
+			const summary = await summaly(host);
+			expect(summary.thumbnailStyle).toBe(expected);
 		});
 
 		test('Player detection - PeerTube:video => video', async () => {


### PR DESCRIPTION
## What

`twitter:card` の値を読み取り、 `thumbnailStyle` として返すように

`twitter:card` では `summary` と `summary_large_image` 以外の表示にも対応するが、summalyではあえてこの2種だけを返す（あれなら後で増やせば良い）

## Why

https://github.com/misskey-dev/misskey/issues/17391
